### PR TITLE
[FIx] 리지드바디가 없어서 발생하는 문제 해결 + 소리 문제 해결

### DIFF
--- a/Q_03/.vsconfig
+++ b/Q_03/.vsconfig
@@ -1,0 +1,6 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Workload.ManagedGame"
+  ]
+}

--- a/Q_03/Assets/Prefabs/Bullet.prefab
+++ b/Q_03/Assets/Prefabs/Bullet.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8690463402006771651}
   - component: {fileID: 8690463402006771660}
+  - component: {fileID: -4616403005672892533}
   m_Layer: 0
   m_Name: Bullet
   m_TagString: Untagged
@@ -48,6 +49,22 @@ MonoBehaviour:
   _force: 20
   _deactivateTime: 5
   _damageValue: 2
+--- !u!54 &-4616403005672892533
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8690463402006771661}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &8690463403069466159
 GameObject:
   m_ObjectHideFlags: 0

--- a/Q_03/Assets/Scenes/SampleScene.unity
+++ b/Q_03/Assets/Scenes/SampleScene.unity
@@ -300,6 +300,27 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1228935934 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8254210141019104514, guid: 8df3ce14876fc4f40ab6a6a736312498, type: 3}
+  m_PrefabInstance: {fileID: 1930269158}
+  m_PrefabAsset: {fileID: 0}
+--- !u!54 &1228935939
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1228935934}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1001 &1930269158
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -307,6 +328,18 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: -117981830401906550, guid: 8df3ce14876fc4f40ab6a6a736312498, type: 3}
+      propertyPath: m_PlayOnAwake
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -117981830401906550, guid: 8df3ce14876fc4f40ab6a6a736312498, type: 3}
+      propertyPath: panLevelCustomCurve.m_Curve.Array.data[0].value
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604936509990062795, guid: 8df3ce14876fc4f40ab6a6a736312498, type: 3}
+      propertyPath: <Hp>k__BackingField
+      value: 4
+      objectReference: {fileID: 0}
     - target: {fileID: 8254210140490314265, guid: 8df3ce14876fc4f40ab6a6a736312498, type: 3}
       propertyPath: m_Name
       value: Player
@@ -317,7 +350,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8254210140490314266, guid: 8df3ce14876fc4f40ab6a6a736312498, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 14.69
+      value: 6.16
       objectReference: {fileID: 0}
     - target: {fileID: 8254210140490314266, guid: 8df3ce14876fc4f40ab6a6a736312498, type: 3}
       propertyPath: m_LocalPosition.y
@@ -325,7 +358,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8254210140490314266, guid: 8df3ce14876fc4f40ab6a6a736312498, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 17.79
+      value: 3.81
       objectReference: {fileID: 0}
     - target: {fileID: 8254210140490314266, guid: 8df3ce14876fc4f40ab6a6a736312498, type: 3}
       propertyPath: m_LocalRotation.w
@@ -353,6 +386,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8254210140490314266, guid: 8df3ce14876fc4f40ab6a6a736312498, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8254210141019104516, guid: 8df3ce14876fc4f40ab6a6a736312498, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8254210141019104516, guid: 8df3ce14876fc4f40ab6a6a736312498, type: 3}
+      propertyPath: m_IsTrigger
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []

--- a/Q_03/Assets/Scripts/BulletController.cs
+++ b/Q_03/Assets/Scripts/BulletController.cs
@@ -26,8 +26,8 @@ public class BulletController : PooledBehaviour
     {
         if (other.CompareTag("Player"))
         {
-            other
-                .GetComponent<PlayerController>()
+            other.
+                GetComponentInParent<PlayerController>() // ¼öÁ¤
                 .TakeHit(_damageValue);
         }
     }

--- a/Q_03/Assets/Scripts/PlayerController.cs
+++ b/Q_03/Assets/Scripts/PlayerController.cs
@@ -33,6 +33,8 @@ public class PlayerController : MonoBehaviour
     public void Die()
     {
         _audio.Play();
-        gameObject.SetActive(false);
+        GameObject body = transform.GetChild(0).gameObject;                  // 수정된 부분
+        body.SetActive(false);                                               // 수정된 부분
+        Destroy(gameObject, 1f);                                             // 수정된 부분
     }
 }

--- a/Q_03/Assets/Scripts/TurretController.cs
+++ b/Q_03/Assets/Scripts/TurretController.cs
@@ -19,8 +19,10 @@ public class TurretController : MonoBehaviour
 
     private void OnTriggerEnter(Collider other)
     {
+        Debug.Log("µé¾î¿È");
         if (other.CompareTag("Player"))
         {
+            Debug.Log("µé¾î¿È");
             Fire(other.transform);
         }
     }

--- a/Q_03/README.md
+++ b/Q_03/README.md
@@ -21,4 +21,16 @@
 제시된 프로젝트에서 발생하는 `문제들을 모두 서술`하고 올바르게 동작하도록 `소스코드를 개선`하시오.
 
 ## 답안
-- 
+ - 1. 리지드바디가 없어서 충돌을 감지하지 못하는 문제.
+ 해결 : 플레이어에 리지드 바디 추가
+
+ - 2. bullet에 리지드바디가 없어서 Fire메서드의 rigid.Addforce가 동작하지 않음
+ 해결 : bullet에 리지드 바디 추가
+
+ - 3. bullet이 플레이어에게 닿았을 때 감지하지 못하는 문제 발생. 
+ => 트리거에 닿은 player 태그를 가진 물체가 rigidbody를 들고 있어야 하고 playercontroller도 들고 있어야하기 때문에 body가 아닌
+ player오브젝트에 rigidbody와 collider를 두기 or other.Getcomponent<PlayerController> -> other.GetComponentInParent<PlayerController>로 수정해야 함
+ (나는 후자 선택)
+
+ - 4. 플레이어가 사망할 때 플레이어가 꺼지기 때문에 오디오를 재생하지 못함(재생했지만 바로 삭제되서 안들리는 것) 
+ => 자연스럽게 보이기 위해 사망할 시 player오브젝트가 아닌 body오브젝트를 꺼지게 함.(수정된 부분 표시) 1초뒤에 플레이어 오브젝트도 삭제.(삭제하지 않으니 계속 트리거 인식)


### PR DESCRIPTION
- 플레이어와 bullet에 리지드바디가 없어서 기능이 실행되지 않는 부분 수정
- 플레이어 피격시에 리지드바디와 playerController를 모두 들고 있어야 하기 때문에 GetComponentInParent로 변경
- 플레이어 사망시 꺼짐으로써 오디오가 재생되지 못해 body만 꺼지게해서 사라진듯 보이게 하고 음원재생 1초뒤에 player도 삭제