### PR TITLE
[Fix] 코드진행이 막히던 문제 + 스택오버플로우 수정

### DIFF
--- a/Q_04/.vsconfig
+++ b/Q_04/.vsconfig
@@ -1,0 +1,6 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Workload.ManagedGame"
+  ]
+}

--- a/Q_04/Assets/Scripts/StateAttack.cs
+++ b/Q_04/Assets/Scripts/StateAttack.cs
@@ -32,7 +32,7 @@ public class StateAttack : PlayerState
 
     public override void Exit()
     {
-        Machine.ChangeState(StateType.Idle);
+        
     }
 
     private void Attack()
@@ -46,7 +46,10 @@ public class StateAttack : PlayerState
         foreach (Collider col in cols)
         {
             damagable = col.GetComponent<IDamagable>();
+            if (!col.TryGetComponent(out damagable))
+                return;
             damagable.TakeHit(Controller.AttackValue);
+            
         }
     }
 
@@ -55,7 +58,8 @@ public class StateAttack : PlayerState
         yield return _wait;
 
         Attack();
-        Exit();
+        Machine.ChangeState(StateType.Idle);    // 수정된 부분
+        yield break;
     }
 
 }

--- a/Q_04/README.md
+++ b/Q_04/README.md
@@ -18,4 +18,9 @@
 제시된 프로젝트에서 발생하는 `문제들을 모두 서술`하고 올바르게 동작하도록 `소스코드를 개선`하시오.
 
 ## 답안
-- 
+- 1. Attack 메서드에서 damageble이 IDamagable을 상속받지 않는 오브젝트들을 인식하지 못해서 상속받지 않는 오브젝트들에게도 TakeHit메서드를 실행시키려 하니 참조오류가 발생.
+=> if(!col.TryGetComponent(out damageble)) return; 을 통해 IDamagable을 상속받지 않았을 경우 넘어가도록 수정
+
+- 2. 공격을 하고 난뒤에 스택오버플로우에 빠지면서 상태가 전환되지 않는 문제가 발생
+=> 코드를 보니 attackstate의 Exit부분에서 ChangeState 메서드를 호출하게 되는데 ChangeState 메서드 내에 현재 state의 Exit를 호출하는 부분이 있음.
+=> 이로 인해 Exit를 무한히 반복하는 스택오버플로우 발생하면서 상태가 전환되지 않게되어서 Machine.ChangeState(StateType.Idle)을 DelayRoutine 코루틴 내의 Exit()를 지우고 해당위치에 넣음


### PR DESCRIPTION
- 상속받지 않는 오브젝트에게 상속메서드를 호출하려 하니 코드 진행이 막혔던 문제 수정
- 무한히 Exit메서드를 호출하던 스택오버플로우 수정