### PR TITLE
[Fix] 레이캐스트 방향 수정

### DIFF
--- a/Q_06/Assets/Scenes/SampleScene.unity
+++ b/Q_06/Assets/Scenes/SampleScene.unity
@@ -131,7 +131,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 544023764665276946, guid: 7077a7e4b41694f8d8f125aa9a5a7afd, type: 3}
       propertyPath: m_Name
-      value: Enemy (1)
+      value: Enemy2
       objectReference: {fileID: 0}
     - target: {fileID: 544023764665276950, guid: 7077a7e4b41694f8d8f125aa9a5a7afd, type: 3}
       propertyPath: m_RootOrder
@@ -379,7 +379,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 544023764665276946, guid: 7077a7e4b41694f8d8f125aa9a5a7afd, type: 3}
       propertyPath: m_Name
-      value: Enemy (2)
+      value: Enemy3
       objectReference: {fileID: 0}
     - target: {fileID: 544023764665276950, guid: 7077a7e4b41694f8d8f125aa9a5a7afd, type: 3}
       propertyPath: m_RootOrder

--- a/Q_06/Assets/Scripts/Gun.cs
+++ b/Q_06/Assets/Scripts/Gun.cs
@@ -10,7 +10,7 @@ public class Gun : MonoBehaviour
     
     public void Fire(Transform origin)
     {
-        Ray ray = new(origin.position, Vector3.forward);
+        Ray ray = new(origin.position, transform.forward);
         RaycastHit hit;
 
         if (Physics.Raycast(ray, out hit, _range, _targetLayer))

--- a/Q_06/README.md
+++ b/Q_06/README.md
@@ -16,3 +16,6 @@
 
 - 2. 카메라의 위치가 설정되지 않아있던 문제
 => 카메라의 transform.position을 muzzlepoint로 설정하고 바라보는 방향을 LookAt(transform.position + muzzlepoint.forward)로 설정하여 1인칭 시점 구현
+
+- 3. 레이캐스트가 월드의 forward 방향으로 고정적으로 발사되고 있던 문제
+=> transform.forward로 수정하여 시점이 바뀌면 해당방향으로 발사되도록 수정


### PR DESCRIPTION
- 레이캐스트가 쏘는 방향이 월드기준 forward로만 고정되어 있던 것을 현재 바라보는 방향의 transform.forward로 수정